### PR TITLE
Fix bug with const version of `at`

### DIFF
--- a/rabbit.hpp
+++ b/rabbit.hpp
@@ -792,7 +792,7 @@ public:
   {
     type_check<array_tag>();
     range_check(index);
-    return const_value_ref_type(&((*value_)[index]), *alloc_);
+    return const_value_ref_type(&((*value_)[index]), alloc_);
   }
 
   value_ref_type operator[](std::size_t index) { return at(index); }


### PR DESCRIPTION
The allocator was being dereferenced when it shouldn't have been. This
brings the const version in line with what the constructor expects and
the non const version already does.