### PR TITLE
Fixes being able to build objects with a tag, the constructors before

### DIFF
--- a/rabbit.hpp
+++ b/rabbit.hpp
@@ -987,7 +987,7 @@ public:
   template <typename Tag>
   basic_value(Tag tag, allocator_type& alloc, typename details::enable_if< details::is_tag<Tag> >::type* = 0)
     : member_type(new native_value_type(Tag::native_value))
-    , base_type(member_type::value_impl_.get(), member_type::alloc_impl_.get())
+    , base_type(member_type::value_impl_.get(), &alloc)
   {}
 
   template <typename T>

--- a/rabbit.hpp
+++ b/rabbit.hpp
@@ -986,18 +986,18 @@ public:
 
   template <typename Tag>
   basic_value(Tag tag, allocator_type& alloc, typename details::enable_if< details::is_tag<Tag> >::type* = 0)
-    : member_type(new native_value_type(Tag::native_value), &alloc)
+    : member_type(new native_value_type(Tag::native_value))
     , base_type(member_type::value_impl_.get(), member_type::alloc_impl_.get())
   {}
 
   template <typename T>
-  basic_value(const T& value, typename details::disable_if< details::is_value_ref<T> >::type* = 0)
+  basic_value(const T& value, typename details::disable_if< details::is_value_ref<T> >::type* = 0, typename details::disable_if< details::is_tag<T> >::type* = 0)
     : member_type(new native_value_type(value), new allocator_type())
     , base_type(member_type::value_impl_.get(), member_type::alloc_impl_.get())
   {}
 
   template <typename T>
-  basic_value(const T& value, allocator_type& alloc, typename details::disable_if< details::is_value_ref<T> >::type* = 0)
+  basic_value(const T& value, allocator_type& alloc, typename details::disable_if< details::is_value_ref<T> >::type* = 0, typename details::disable_if< details::is_tag<T> >::type* = 0)
     : member_type(new native_value_type(value))
     , base_type(member_type::value_impl_.get(), &alloc)
   {}

--- a/test/value_test.cpp
+++ b/test/value_test.cpp
@@ -340,6 +340,52 @@ BOOST_AUTO_TEST_SUITE(as_test) // {{{
   }
 BOOST_AUTO_TEST_SUITE_END() // }}}
 
+
+BOOST_AUTO_TEST_CASE(value_construct_by_value_test){
+  {
+    rabbit::value v1(123);
+    BOOST_CHECK(v1.is_int());
+
+    rabbit::value::allocator_type a;
+    rabbit::value v2(123, a);
+    BOOST_CHECK(v2.is_int());
+  }
+
+  {
+    rabbit::value v1("abc");
+    BOOST_CHECK(v1.is_string());
+
+    rabbit::value::allocator_type a;
+    rabbit::value v2("abc", a);
+    BOOST_CHECK(v2.is_string());
+  }
+
+  {
+    rabbit::value v1(123.5);
+    BOOST_CHECK(v1.is_double());
+
+    rabbit::value::allocator_type a;
+    rabbit::value v2(123.5, a);
+    BOOST_CHECK(v2.is_double());
+  }
+
+
+}
+
+
+
+
+BOOST_AUTO_TEST_CASE(value_construct_by_tag_test){
+  rabbit::value v1((rabbit::object_tag())); //Extra parens for most vexing parse
+  BOOST_CHECK(v1.is_object());
+
+  rabbit::value::allocator_type a;
+  rabbit::value v2((rabbit::object_tag()), a);
+  BOOST_CHECK(v2.is_object());
+}
+
+
+
 BOOST_AUTO_TEST_CASE(clear_test)
 {
   rabbit::value v(123);


### PR DESCRIPTION
were ambiguous with the value builds. Additionally the tag constructor
that takes an allocator winds up "stealing" ownership of the allocator
when it shouldn't. This brings that constructor in line with how other
constructors that take the allocator work, and fixes the double free
segfault when both the allocator and rabbit::value goes out of scope.


Previous errors without the change:
```

/home/user/csteifel/rabbittest/rabbit/test/value_test.cpp:379:42: error: call of overloaded 'basic_value(rabbit::object_tag)' is ambiguous
   rabbit::value v1((rabbit::object_tag())); //Extra parens for most vexing parse
                                          ^
In file included from /home/user/csteifel/rabbittest/rabbit/test/value_test.cpp:3:0:
/home/user/csteifel/rabbittest/rabbit/rabbit.hpp:1007:3: note: candidate: rabbit::basic_value<Traits, DefaultTag>::basic_value(const rabbit::basic_value<Traits, DefaultTag>&) [with Traits = rabbit::details::value_ref_traits<rapidjson::UTF8<> >; DefaultTag = rabbit::null_tag]
   basic_value(const basic_value& other)
   ^
/home/user/csteifel/rabbittest/rabbit/rabbit.hpp:995:3: note: candidate: rabbit::basic_value<Traits, DefaultTag>::basic_value(const T&, typename rabbit::details::disable_if<rabbit::details::is_value_ref<T> >::type*) [with T = rabbit::object_tag; Traits = rabbit::details::value_ref_traits<rapidjson::UTF8<> >; DefaultTag = rabbit::null_tag; typename rabbit::details::disable_if<rabbit::details::is_value_ref<T> >::type = void]
   basic_value(const T& value, typename details::disable_if< details::is_value_ref<T> >::type* = 0)
   ^
/home/user/csteifel/rabbittest/rabbit/rabbit.hpp:982:3: note: candidate: rabbit::basic_value<Traits, DefaultTag>::basic_value(Tag, typename rabbit::details::enable_if<rabbit::details::is_tag<Tag> >::type*) [with Tag = rabbit::object_tag; Traits = rabbit::details::value_ref_traits<rapidjson::UTF8<> >; DefaultTag = rabbit::null_tag; typename rabbit::details::enable_if<rabbit::details::is_tag<Tag> >::type = void]
   basic_value(Tag tag, typename details::enable_if< details::is_tag<Tag> >::type* = 0)
   ^
make[2]: *** [test/CMakeFiles/value_test.dir/value_test.cpp.o] Error 1
make[1]: *** [test/CMakeFiles/value_test.dir/all] Error 2
make: *** [all] Error 2

```