### PR TITLE
Creating values and pushing back based on std::strings or c_strings didn't work as expected

### DIFF
--- a/rabbit.hpp
+++ b/rabbit.hpp
@@ -28,7 +28,6 @@
 #ifndef RABBIT_NAMESPACE
 #define RABBIT_NAMESPACE rabbit
 #endif
-#include <iostream>
 
 #include <string>
 #include <stdexcept>

--- a/rabbit.hpp
+++ b/rabbit.hpp
@@ -704,7 +704,24 @@ public:
   }
 
   template <typename T>
-  void insert(const string_ref_type& name, const T& value, typename details::disable_if< details::is_value_ref<T> >::type* = 0)
+  void insert(const string_ref_type& name, const T& value, typename details::disable_if< details::is_value_ref<T> >::type* = 0, typename details::enable_if< details::is_string<T> >::type * = 0)
+  {
+    type_check<object_tag>();
+    native_value_type v(value.data(), value.length(), *alloc_);
+    value_->AddMember(rapidjson::StringRef(name.data(), name.length()), v, *alloc_);
+  }
+
+  template <typename T>
+  void insert(const string_ref_type& name, const T& value, typename details::disable_if< details::is_value_ref<T> >::type* = 0, typename details::enable_if< details::is_cstr_ptr<T> >::type * = 0)
+  {
+    type_check<object_tag>();
+    native_value_type v(value, *alloc_);
+    value_->AddMember(rapidjson::StringRef(name.data(), name.length()), v, *alloc_);
+  }
+
+
+  template <typename T>
+  void insert(const string_ref_type& name, const T& value, typename details::disable_if< details::is_value_ref<T> >::type* = 0, typename details::disable_if< details::is_string<T> >::type * = 0, typename details::disable_if< details::is_cstr_ptr<T> >::type * = 0)
   {
     type_check<object_tag>();
     native_value_type v(value);

--- a/test/array_test.cpp
+++ b/test/array_test.cpp
@@ -176,3 +176,20 @@ BOOST_AUTO_TEST_CASE(const_iterator_test)
   }
 }
 
+BOOST_AUTO_TEST_CASE(push_back_strings){
+  rabbit::array a;
+  a.push_back("abc");
+
+  std::string s("some sort of string");
+  a.push_back(s); 
+
+  char * cs = (char *) calloc(sizeof(char), 4);
+  memcpy(cs, "def", 4);
+  a.push_back(cs);
+
+
+  BOOST_CHECK(a.size() == 3);
+  BOOST_CHECK(a[0].as_string() == "abc");
+  BOOST_CHECK(a[1].as_string() == s);
+  BOOST_CHECK(a[2].as_string() == "def");
+}

--- a/test/value_test.cpp
+++ b/test/value_test.cpp
@@ -1,6 +1,7 @@
 #define BOOST_TEST_MODULE value_test
 #include <boost/test/unit_test.hpp>
 #include <rabbit.hpp>
+#include <iostream>
 
 BOOST_AUTO_TEST_SUITE(is_test) // {{{
   BOOST_AUTO_TEST_CASE(null_test)
@@ -519,4 +520,35 @@ BOOST_AUTO_TEST_CASE(deep_copy_const_value)
 
 
 
+}
+
+BOOST_AUTO_TEST_CASE(value_create_by_string){
+  rabbit::value v1("str");
+  BOOST_CHECK(v1.as_string() == "str");
+  std::string s("Some really long string that shouldn't actually fit into short string optimizations in the rapidjson library.");
+  rabbit::value v2(s);
+  BOOST_CHECK(v2.as_string() == s);
+
+
+  char * cs = (char *) calloc(sizeof(char), 10);
+  memcpy(cs, "abcde", 5);
+  rabbit::value v3(cs);
+  free(cs);
+  BOOST_CHECK(v3.as_string() == "abcde");
+}
+
+
+BOOST_AUTO_TEST_CASE(value_create_by_op_eq_string){
+  rabbit::value v1 = "str";
+  BOOST_CHECK(v1.as_string() == "str");
+  std::string s("Some really long string that shouldn't actually fit into short string optimizations in the rapidjson library.");
+  rabbit::value v2 = s;
+  BOOST_CHECK(v2.as_string() == s);
+
+
+  char * cs = (char *) calloc(sizeof(char), 10);
+  memcpy(cs, "abcde", 5);
+  rabbit::value v3 = cs;
+  free(cs);
+  BOOST_CHECK(v3.as_string() == "abcde");
 }

--- a/test/value_test.cpp
+++ b/test/value_test.cpp
@@ -1,7 +1,6 @@
 #define BOOST_TEST_MODULE value_test
 #include <boost/test/unit_test.hpp>
 #include <rabbit.hpp>
-#include <iostream>
 
 BOOST_AUTO_TEST_SUITE(is_test) // {{{
   BOOST_AUTO_TEST_CASE(null_test)

--- a/test/value_test.cpp
+++ b/test/value_test.cpp
@@ -551,3 +551,25 @@ BOOST_AUTO_TEST_CASE(value_create_by_op_eq_string){
   free(cs);
   BOOST_CHECK(v3.as_string() == "abcde");
 }
+
+
+
+BOOST_AUTO_TEST_CASE(value_insert_string){
+  rabbit::object v;
+  v.insert("abc", "def");
+  BOOST_CHECK(v["abc"].as_string() == "def");
+
+
+  std::string s("stringTest");
+  v.insert("ghi", s);
+  BOOST_CHECK(v["ghi"].as_string() == s);
+
+
+  char * cs = (char *) calloc(sizeof(char), 10);
+  memcpy(cs, "abcde", 5);
+  v.insert("xyz", cs);
+  free(cs);
+
+  BOOST_CHECK(v["xyz"].as_string() == "abcde");
+
+}


### PR DESCRIPTION
Doing `rabbit::value v("abc");` worked

However the following wasn't working

```
rabbit::array a;
std::string s("abc");
a.push_back(s);
```

and

```
std::string s("abc");
rabbit::value v(s);
```

were failing to compile since the rapidjson values have to be created with an allocator to copy the string.