### PR TITLE
Fixing handling of getting numeric values as doubles

### DIFF
--- a/rabbit.hpp
+++ b/rabbit.hpp
@@ -680,7 +680,6 @@ public:
   RABBIT_AS_DEF(unsigned, uint, Uint)
   RABBIT_AS_DEF(int64_t, int64, Int64)
   RABBIT_AS_DEF(uint64_t, uint64, Uint64)
-  //RABBIT_AS_DEF(double, double, Double)
   RABBIT_AS_DEF(string_type, string, String)
 #undef RABBIT_AS_DEF
   double as_double() const

--- a/rabbit.hpp
+++ b/rabbit.hpp
@@ -595,7 +595,7 @@ public:
     else if (value.is_object()) throw std::runtime_error("can not assign object directly. please use insert");
   }
 
-  template <typename OtherTraits> 
+  template <typename OtherTraits>
   void deep_copy(const basic_value_ref<OtherTraits>& other)
   {
     value_->CopyFrom(*other.get_native_value_pointer(), *alloc_);
@@ -680,9 +680,30 @@ public:
   RABBIT_AS_DEF(unsigned, uint, Uint)
   RABBIT_AS_DEF(int64_t, int64, Int64)
   RABBIT_AS_DEF(uint64_t, uint64, Uint64)
-  RABBIT_AS_DEF(double, double, Double)
+  //RABBIT_AS_DEF(double, double, Double)
   RABBIT_AS_DEF(string_type, string, String)
 #undef RABBIT_AS_DEF
+  double as_double() const
+  {
+    if(!is_number()){
+      std::stringstream ss;
+      ss << "value is not ";
+      ss << details::type_name<double>();
+      ss << " (which is " << which() << ")";
+      throw type_mismatch(ss.str());
+    }
+    return value_->GetDouble();
+  }
+
+  template <typename T>
+  T as(typename details::enable_if< details::is_double<T> >::type* = 0) const
+  {
+    return as_double();
+  }
+
+
+
+
 
 private:
   struct as_t
@@ -1041,7 +1062,7 @@ struct basic_value_base
 };
 
 template <typename Traits, typename DefaultTag = null_tag>
-class basic_value 
+class basic_value
   : private basic_value_base<Traits>
   , public basic_value_ref<Traits>
 {
@@ -1086,7 +1107,7 @@ public:
 
 
   /*
-   *        Tag based constructors  
+   *        Tag based constructors
    */
   template <typename Tag>
   basic_value(Tag tag, typename details::enable_if< details::is_tag<Tag> >::type* = 0)

--- a/test/value_test.cpp
+++ b/test/value_test.cpp
@@ -284,8 +284,8 @@ BOOST_AUTO_TEST_SUITE(as_test) // {{{
     BOOST_CHECK_EQUAL(v.as<int64_t>(), 123);
     BOOST_CHECK_EQUAL(v.as_uint64(), 123);
     BOOST_CHECK_EQUAL(v.as<uint64_t>(), 123);
-    BOOST_CHECK_THROW(v.as_double(), rabbit::type_mismatch);
-    BOOST_CHECK_THROW(v.as<double>(), rabbit::type_mismatch);
+    BOOST_CHECK_CLOSE(v.as_double(), 123.0, 0.00001);
+    BOOST_CHECK_CLOSE(v.as<double>(), 123.0, 0.00001);
     BOOST_CHECK_THROW(v.as_string(), rabbit::type_mismatch);
     BOOST_CHECK_THROW(v.as<std::string>(), rabbit::type_mismatch);
   }
@@ -309,6 +309,28 @@ BOOST_AUTO_TEST_SUITE(as_test) // {{{
     BOOST_CHECK_THROW(v.as_string(), rabbit::type_mismatch);
     BOOST_CHECK_THROW(v.as<std::string>(), rabbit::type_mismatch);
   }
+
+  BOOST_AUTO_TEST_CASE(double_from_int_test)
+  {
+    rabbit::value v(123);
+
+    BOOST_CHECK_THROW(v.as_bool(), rabbit::type_mismatch);
+    BOOST_CHECK_THROW(v.as<bool>(), rabbit::type_mismatch);
+    BOOST_CHECK_EQUAL(v.as_int(), 123);
+    BOOST_CHECK_EQUAL(v.as<int>(), 123);
+    BOOST_CHECK_EQUAL(v.as_uint(), 123);
+    BOOST_CHECK_EQUAL(v.as<unsigned>(), 123);
+    BOOST_CHECK_EQUAL(v.as_int64(), 123);
+    BOOST_CHECK_EQUAL(v.as<int64_t>(), 123);
+    BOOST_CHECK_EQUAL(v.as_uint64(), 123);
+    BOOST_CHECK_EQUAL(v.as<uint64_t>(), 123);
+    BOOST_CHECK_CLOSE(v.as_double(), 123.0, 0.00001);
+    BOOST_CHECK_CLOSE(v.as<double>(), 123.0, 0.00001);
+    BOOST_CHECK_THROW(v.as_string(), rabbit::type_mismatch);
+    BOOST_CHECK_THROW(v.as<std::string>(), rabbit::type_mismatch);
+  }
+
+
 
   BOOST_AUTO_TEST_CASE(string_test)
   {
@@ -572,4 +594,63 @@ BOOST_AUTO_TEST_CASE(value_insert_string){
 
   BOOST_CHECK(v["xyz"].as_string() == "abcde");
 
+}
+
+
+
+BOOST_AUTO_TEST_CASE(rabbit_number_is_and_as_compared_to_rapid){
+  {
+    rabbit::value v(123);
+    BOOST_CHECK_EQUAL(v.is_int(), v.get_native_value_pointer()->IsInt());
+    BOOST_CHECK_EQUAL(v.is_uint(), v.get_native_value_pointer()->IsUint());
+    BOOST_CHECK_EQUAL(v.is_int64(), v.get_native_value_pointer()->IsInt64());
+    BOOST_CHECK_EQUAL(v.is_uint64(), v.get_native_value_pointer()->IsUint64());
+    BOOST_CHECK_EQUAL(v.is_double(), v.get_native_value_pointer()->IsDouble());
+
+    BOOST_CHECK_EQUAL(v.as_int(), v.get_native_value_pointer()->GetInt());
+    BOOST_CHECK_EQUAL(v.as_uint(), v.get_native_value_pointer()->GetUint());
+    BOOST_CHECK_EQUAL(v.as_int64(), v.get_native_value_pointer()->GetInt64());
+    BOOST_CHECK_EQUAL(v.as_uint64(), v.get_native_value_pointer()->GetUint64());
+    BOOST_CHECK_EQUAL(v.as_double(), v.get_native_value_pointer()->GetDouble());
+  }
+
+  {
+    rabbit::value v(4294967295);
+    BOOST_CHECK_EQUAL(v.is_int(), v.get_native_value_pointer()->IsInt());
+    BOOST_CHECK_EQUAL(v.is_uint(), v.get_native_value_pointer()->IsUint());
+    BOOST_CHECK_EQUAL(v.is_int64(), v.get_native_value_pointer()->IsInt64());
+    BOOST_CHECK_EQUAL(v.is_uint64(), v.get_native_value_pointer()->IsUint64());
+    BOOST_CHECK_EQUAL(v.is_double(), v.get_native_value_pointer()->IsDouble());
+
+    BOOST_CHECK_EQUAL(v.as_uint(), v.get_native_value_pointer()->GetUint());
+    BOOST_CHECK_EQUAL(v.as_int64(), v.get_native_value_pointer()->GetInt64());
+    BOOST_CHECK_EQUAL(v.as_uint64(), v.get_native_value_pointer()->GetUint64());
+    BOOST_CHECK_EQUAL(v.as_double(), v.get_native_value_pointer()->GetDouble());
+  }
+
+
+  {
+    rabbit::value v(9223372036854775807);
+    BOOST_CHECK_EQUAL(v.is_int(), v.get_native_value_pointer()->IsInt());
+    BOOST_CHECK_EQUAL(v.is_uint(), v.get_native_value_pointer()->IsUint());
+    BOOST_CHECK_EQUAL(v.is_int64(), v.get_native_value_pointer()->IsInt64());
+    BOOST_CHECK_EQUAL(v.is_uint64(), v.get_native_value_pointer()->IsUint64());
+    BOOST_CHECK_EQUAL(v.is_double(), v.get_native_value_pointer()->IsDouble());
+
+    BOOST_CHECK_EQUAL(v.as_int64(), v.get_native_value_pointer()->GetInt64());
+    BOOST_CHECK_EQUAL(v.as_uint64(), v.get_native_value_pointer()->GetUint64());
+    BOOST_CHECK_EQUAL(v.as_double(), v.get_native_value_pointer()->GetDouble());
+  }
+
+  {
+    rabbit::value v(static_cast<uint64_t>(9223372036854775808ULL));
+    BOOST_CHECK_EQUAL(v.is_int(), v.get_native_value_pointer()->IsInt());
+    BOOST_CHECK_EQUAL(v.is_uint(), v.get_native_value_pointer()->IsUint());
+    BOOST_CHECK_EQUAL(v.is_int64(), v.get_native_value_pointer()->IsInt64());
+    BOOST_CHECK_EQUAL(v.is_uint64(), v.get_native_value_pointer()->IsUint64());
+    BOOST_CHECK_EQUAL(v.is_double(), v.get_native_value_pointer()->IsDouble());
+
+    BOOST_CHECK_EQUAL(v.as_uint64(), v.get_native_value_pointer()->GetUint64());
+    BOOST_CHECK_EQUAL(v.as_double(), v.get_native_value_pointer()->GetDouble());
+  }
 }


### PR DESCRIPTION
RapidJson will allow you to convert integers to doubles, however, the
type checking in rabbit disallowed this. There is a caveat for really
really large numbers that you may lose precision but RapidJSON still
allows it